### PR TITLE
Update outdated comparison with Telepresence

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,15 +57,16 @@ Looking for Homebrew or Windows installation? Checkout the [installation guide](
 If you are interested in more sophisticated use cases or want to develop modern Kubernetes-based architectures, 
 check out the [use cases and demos](/usecases/) or [the media section](/media/). 
 
-## Alternative to Telepresence 2
-Compared to [Telepresence 2](https://www.telepresence.io/docs/latest/reference/architecture/){:target="_blank"}, Gefyra uses a Wireguard-based
-VPN to connect with the Kubernetes cluster. Telepresence 2 provides a broad connectivity with the cluster ("your development
-machine becomes part of the cluster"), Gefyra instead establishes a very scoped connectivity based on a dedicated Docker-network on the
-developer machine. In addition, Gefyra supports a couple of important use-cases such as the sidecar pattern 
-(see: [this medium article](https://medium.com/bb-tutorials-and-thoughts/kubernetes-learn-sidecar-container-pattern-6d8c21f873d){:target="_blank"}) and does not require
-"sudo"-privileges during the development process.  
+## Alternative to Telepresence
+Compared to [Telepresence](https://www.getambassador.io/docs/telepresence/latest/reference/architecture){:target="_blank"}, Gefyra uses a Wireguard-based
+VPN to connect with the Kubernetes cluster. Telepresence provides namespace-scoped connectivity with the cluster via a virtual network interface, and tunnels over gRPC.
+
+Unlike Gefyra, Telepresence can run with or without Docker. Docker is fully exploited when used, so no "sudo"-privileges are needed, and both network and volume mounts are fully isolated from the host. Without Docker, Telepresence requires "sudo"-privliges to add a virtual network interface and inject a DNS server on the host. 
+
+Like Gefyra, Telepresence uses a sidecar pattern to inject the container(s) needed to perform intercepts.
+
 Anyway, if you feel you need other features that Telepresence 2 provides and Gefyra misses, please give it a go. Gefyra was heavily 
-inspired by Telepresence 2.
+inspired by Telepresence.
 
 Gefyra was designed to be fast and robust on an average developer machine and supports most platforms.
 

--- a/index.md
+++ b/index.md
@@ -61,7 +61,7 @@ check out the [use cases and demos](/usecases/) or [the media section](/media/).
 Compared to [Telepresence](https://www.getambassador.io/docs/telepresence/latest/reference/architecture){:target="_blank"}, Gefyra uses a Wireguard-based
 VPN to connect with the Kubernetes cluster. Telepresence provides namespace-scoped connectivity with the cluster via a virtual network interface, and tunnels over gRPC.
 
-Unlike Gefyra, Telepresence can run with or without Docker. Docker is fully exploited when used, so no "sudo"-privileges are needed, and both network and volume mounts are fully isolated from the host. Without Docker, Telepresence requires "sudo"-privliges to add a virtual network interface and inject a DNS server on the host. 
+Gefyra comes with Docker as backed-in dependency. With Telepresence, Docker is optional. 
 
 Telepresence uses a sidecar pattern to inject the container(s) needed to perform selective intercepts (the original container will receive unintercepted traffic). Gefyra instead replaces the image of the intercepted container with the Gefyra `carrier` image, which then redirects traffic to the local container. Gefyra can therefore support a couple of important use-cases such as the sidecar pattern (see: [this medium article](https://medium.com/bb-tutorials-and-thoughts/kubernetes-learn-sidecar-container-pattern-6d8c21f873d){:target="_blank"}) which require an ability to intercept ports on the localhost.
 

--- a/index.md
+++ b/index.md
@@ -63,9 +63,9 @@ VPN to connect with the Kubernetes cluster. Telepresence provides namespace-scop
 
 Unlike Gefyra, Telepresence can run with or without Docker. Docker is fully exploited when used, so no "sudo"-privileges are needed, and both network and volume mounts are fully isolated from the host. Without Docker, Telepresence requires "sudo"-privliges to add a virtual network interface and inject a DNS server on the host. 
 
-Like Gefyra, Telepresence uses a sidecar pattern to inject the container(s) needed to perform intercepts.
+Telepresence uses a sidecar pattern to inject the container(s) needed to perform selective intercepts (the original container will receive unintercepted traffic). Gefyra instead replaces the image of the intercepted container with the Gefyra `carrier` image, which then redirects traffic to the local container. Gefyra can therefore support a couple of important use-cases such as the sidecar pattern (see: this medium article{:target="_blank"}) which require an ability to intercept ports on the localhost.
 
-Anyway, if you feel you need other features that Telepresence 2 provides and Gefyra misses, please give it a go. Gefyra was heavily 
+Anyway, if you feel you need other features that Telepresence provides and Gefyra misses, please give it a go. Gefyra was heavily 
 inspired by Telepresence.
 
 Gefyra was designed to be fast and robust on an average developer machine and supports most platforms.

--- a/index.md
+++ b/index.md
@@ -63,7 +63,7 @@ VPN to connect with the Kubernetes cluster. Telepresence provides namespace-scop
 
 Unlike Gefyra, Telepresence can run with or without Docker. Docker is fully exploited when used, so no "sudo"-privileges are needed, and both network and volume mounts are fully isolated from the host. Without Docker, Telepresence requires "sudo"-privliges to add a virtual network interface and inject a DNS server on the host. 
 
-Telepresence uses a sidecar pattern to inject the container(s) needed to perform selective intercepts (the original container will receive unintercepted traffic). Gefyra instead replaces the image of the intercepted container with the Gefyra `carrier` image, which then redirects traffic to the local container. Gefyra can therefore support a couple of important use-cases such as the sidecar pattern (see: this medium article{:target="_blank"}) which require an ability to intercept ports on the localhost.
+Telepresence uses a sidecar pattern to inject the container(s) needed to perform selective intercepts (the original container will receive unintercepted traffic). Gefyra instead replaces the image of the intercepted container with the Gefyra `carrier` image, which then redirects traffic to the local container. Gefyra can therefore support a couple of important use-cases such as the sidecar pattern (see: [this medium article](https://medium.com/bb-tutorials-and-thoughts/kubernetes-learn-sidecar-container-pattern-6d8c21f873d){:target="_blank"}) which require an ability to intercept ports on the localhost.
 
 Anyway, if you feel you need other features that Telepresence provides and Gefyra misses, please give it a go. Gefyra was heavily 
 inspired by Telepresence.


### PR DESCRIPTION
A lot has happened since that comparison was written. Telepresence now have full support for Docker. It runs in a Docker container and uses a docker network. It also uses a Docker volume driver to mount remote filesystems in a way that doesn't affect the host.

In addition to that, Telepresence injects the sidecars needed to perform intercepts using a mutating webhook.

Here's an attempt to update the comparison.